### PR TITLE
Fix tool `name` method to strip unsupported characters for OpenAI

### DIFF
--- a/lib/ruby_llm/tool.rb
+++ b/lib/ruby_llm/tool.rb
@@ -50,6 +50,7 @@ module RubyLLM
 
     def name
       self.class.name
+          .gsub(/[^a-zA-Z0-9_-]/, '-')
           .gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2')
           .gsub(/([a-z\d])([A-Z])/, '\1_\2')
           .downcase

--- a/spec/ruby_llm/tool_spec.rb
+++ b/spec/ruby_llm/tool_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'ruby_llm/tool'
+
+RSpec.describe RubyLLM::Tool do
+  describe '#name' do
+    it 'converts class name to snake_case and removes _tool suffix' do
+      class SampleTool < RubyLLM::Tool; end
+      expect(SampleTool.new.name).to eq('sample')
+    end
+
+    it 'replaces unsupported characters with -' do
+      class SampleTòol < RubyLLM::Tool; end
+      expect(SampleTòol.new.name).to eq('sample_t-ol')
+    end
+
+    it 'handles class names with multiple unsupported characters' do
+      class SàmpleTòolèr < RubyLLM::Tool; end
+      expect(SàmpleTòolèr.new.name).to eq('s-mple_t-ol-r')
+    end
+
+    it 'handles class names without _tool suffix' do
+      class AnotherSampleTool < RubyLLM::Tool; end
+      expect(AnotherSampleTool.new.name).to eq('another_sample')
+    end
+
+    it 'handles class names with numbers and underscores' do
+      class SampleTool123 < RubyLLM::Tool; end
+      expect(SampleTool123.new.name).to eq('sample_tool123')
+    end
+
+    it 'strips :: for class in module namespace' do
+      module TestModule
+        class SampleTool < RubyLLM::Tool; end
+      end
+      expect(TestModule::SampleTool.new.name).to eq('test_module--sample')
+    end
+  end
+end


### PR DESCRIPTION
Updates the `name` method in the `Tool` class to strip unsupported characters and replace them with '-' characters as OpenAI only supports tool names with `/a-zA-Z0-9_-/+`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/stevegeek/ruby_llm/pull/1?shareId=7ad24c2b-395f-439b-a4f6-62570fcec55d).